### PR TITLE
add support for macOS 10.12

### DIFF
--- a/makefile
+++ b/makefile
@@ -10,7 +10,7 @@ CC=gcc
 CXX=g++
 else
   UNAME := $(shell uname -s)
-ifeq ($(UNAME),$(filter $(UNAME),Linux Darwin FreeBSD GNU/kFreeBSD))
+ifeq ($(UNAME),$(filter $(UNAME),Linux FreeBSD GNU/kFreeBSD))
 LDFLAGS+= -lrt
 endif
 endif

--- a/time_.h
+++ b/time_.h
@@ -9,8 +9,8 @@
 #define Sleep(ms) usleep((ms) * 1000)
   #endif
 
-#if defined (__i386__) || defined( __x86_64__ ) 
-  #ifdef _MSC_VER  
+#if defined (__i386__) || defined( __x86_64__ )
+  #ifdef _MSC_VER
 #include <intrin.h> // __rdtsc
   #else
 #include <x86intrin.h>
@@ -47,7 +47,7 @@
   #endif
 #else
 #define RDTSC_INI(_c_)
-#define RDTSC(_c_)	  
+#define RDTSC(_c_)
 #endif
 
 #define tmrdtscini() ({ tm_t _c; __asm volatile("" ::: "memory"); RDTSC_INI(_c); _c; })
@@ -71,12 +71,19 @@ typedef unsigned long long tm_t;
     #ifdef _WIN32
 static LARGE_INTEGER tps;
 static tm_t tmtime(void) { LARGE_INTEGER tm; QueryPerformanceCounter(&tm); return (tm_t)((double)tm.QuadPart*1000000.0/tps.QuadPart); }
-static tm_t tminit() { QueryPerformanceFrequency(&tps); tm_t t0=tmtime(),ts; while((ts = tmtime())==t0); return ts; } 
+static tm_t tminit() { QueryPerformanceFrequency(&tps); tm_t t0=tmtime(),ts; while((ts = tmtime())==t0); return ts; }
     #else
-      #ifdef __MACH__
+      #ifdef __APPLE__
+#include <AvailabilityMacros.h>
+        #ifndef MAC_OS_X_VERSION_10_12
+#define MAC_OS_X_VERSION_10_12 101200
+        #endif
+      #endif
+#define CIVETWEB_APPLE_HAVE_CLOCK_GETTIME defined(__APPLE__) && MAC_OS_X_VERSION_MIN_REQUIRED >= MAC_OS_X_VERSION_10_12
+      #if !(CIVETWEB_APPLE_HAVE_CLOCK_GETTIME)
 #include <sys/time.h>
-#define CLOCK_REALTIME 0 
-#define CLOCK_MONOTONIC 0 
+#define CLOCK_REALTIME 0
+#define CLOCK_MONOTONIC 0
 int clock_gettime(int /*clk_id*/, struct timespec* t) {
     struct timeval now;
     int rv = gettimeofday(&now, NULL);
@@ -85,7 +92,7 @@ int clock_gettime(int /*clk_id*/, struct timespec* t) {
     t->tv_nsec = now.tv_usec * 1000;
     return 0;
 }
-      #endif	
+      #endif
 static   tm_t tmtime(void)    { struct timespec tm; clock_gettime(CLOCK_MONOTONIC, &tm); return (tm_t)tm.tv_sec*1000000ull + tm.tv_nsec/1000; }
 static   tm_t tminit()        { tm_t t0=tmtime(),ts; while((ts = tmtime())==t0); return ts; }
     #endif
@@ -94,19 +101,19 @@ static double tmmsec(tm_t tm) { return (double)tm/1000.0; }
 #endif
 //---------------------------------------- bench ----------------------------------------------------------------------
 #define TM_TX TM_T
- 
+
 #define TMSLEEP do { tm_T = tmtime(); if(!tm_0) tm_0 = tm_T; else if(tm_T - tm_0 > tm_TX) { if(tm_verbose) { printf("S \b\b");fflush(stdout);} sleep(tm_slp); tm_0=tmtime();} } while(0)
 
 #define TMBEG(_tm_reps_, _tm_Reps_) { unsigned _tm_r,_tm_c=0,_tm_R; tm_t _tm_t0,_tm_t,_tm_ts;\
   for(tm_rm = _tm_reps_, tm_tm = 1ull<<63,_tm_R = 0,_tm_ts=tmtime(); _tm_R < _tm_Reps_; _tm_R++) { tm_t _tm_t0 = tminit();\
     for(_tm_r=0;_tm_r < tm_rm;) {
- 
+
 #define TMEND(_len_) _tm_r++; if((_tm_t = tmtime() - _tm_t0) > tm_tx) break; } \
   if(_tm_t < tm_tm) { if(tm_tm == 1ull<<63) { tm_rm = _tm_r; /*printf("reps=%d ", tm_rm);*/ } tm_tm = _tm_t; _tm_c++; } \
   else if(_tm_t>tm_tm*1.2) TMSLEEP;   													if(tm_verbose) printf("%8.2f %.2d_%d\b\b\b\b\b\b\b\b\b\b\b\b\b",TMBS(_len_, (double)tm_tm*TM_C/tm_rm),_tm_R+1,_tm_c),fflush(stdout);\
   if(tmtime()-_tm_ts > tm_TX) break;\
   if((_tm_R & 7)==7) sleep(tm_slp),_tm_ts=tmtime(); } }
- 
+
 static unsigned tm_rep = 1<<20, tm_Rep = 3, tm_rep2 = 1<<20, tm_Rep2 = 4, tm_slp = 20, tm_rm;
 static tm_t     tm_tx = TM_T, tm_TX = 10*TM_T, tm_0, tm_T, tm_verbose=1, tm_tm;
 static void tm_init(int _tm_Rep, int _tm_verbose) { tm_verbose = _tm_verbose; if(_tm_Rep) tm_Rep = _tm_Rep; tm_tx =  tminit(); Sleep(500); tm_tx = tmtime() - tm_tx; /*printf("tm_tx=%llu %lld\n", tm_tx, (long long)CLOCKS_PER_SEC);*/ tm_TX = 10*tm_tx; }
@@ -122,7 +129,7 @@ static void tm_init(int _tm_Rep, int _tm_verbose) { tm_verbose = _tm_verbose; if
 #define GB 1000000000
 
 static unsigned argtoi(char *s, unsigned def) {
-  char *p; 
+  char *p;
   unsigned n = strtol(s, &p, 10),f = 1;
   switch(*p) {
     case 'K': f = KB; break;
@@ -132,7 +139,7 @@ static unsigned argtoi(char *s, unsigned def) {
     case 'm': f = Mb; break;
     case 'g': f = Gb; break;
     case 'b': def = 0;
-	default: if(!def) return n>=32?0xffffffffu:(1u << n); f = def; 
+	default: if(!def) return n>=32?0xffffffffu:(1u << n); f = def;
   }
   return n*f;
 }
@@ -147,20 +154,20 @@ static unsigned long long argtol(char *s) {
     case 'm': f = Mb; break;
     case 'g': f = Gb; break;
     case 'b': return 1u << n;
-	default:  f = MB;	
+	default:  f = MB;
   }
   return n*f;
 }
 
 static unsigned long long argtot(char *s) {
   char *p;
-  unsigned long long n = strtol(s, &p, 10),f=1; 
+  unsigned long long n = strtol(s, &p, 10),f=1;
   switch(*p) {
     case 'h': f = 3600000; break;
     case 'm': f = 60000;   break;
     case 's': f = 1000;    break;
     case 'M': f = 1;       break;
-	default:  f = 1000;	
+	default:  f = 1000;
   }
   return n*f;
 }

--- a/time_.h
+++ b/time_.h
@@ -78,9 +78,8 @@ static tm_t tminit() { QueryPerformanceFrequency(&tps); tm_t t0=tmtime(),ts; whi
         #ifndef MAC_OS_X_VERSION_10_12
 #define MAC_OS_X_VERSION_10_12 101200
         #endif
-      #endif
 #define CIVETWEB_APPLE_HAVE_CLOCK_GETTIME defined(__APPLE__) && MAC_OS_X_VERSION_MIN_REQUIRED >= MAC_OS_X_VERSION_10_12
-      #if !(CIVETWEB_APPLE_HAVE_CLOCK_GETTIME)
+        #if !(CIVETWEB_APPLE_HAVE_CLOCK_GETTIME)
 #include <sys/time.h>
 #define CLOCK_REALTIME 0
 #define CLOCK_MONOTONIC 0
@@ -92,6 +91,7 @@ int clock_gettime(int /*clk_id*/, struct timespec* t) {
     t->tv_nsec = now.tv_usec * 1000;
     return 0;
 }
+        #endif
       #endif
 static   tm_t tmtime(void)    { struct timespec tm; clock_gettime(CLOCK_MONOTONIC, &tm); return (tm_t)tm.tv_sec*1000000ull + tm.tv_nsec/1000; }
 static   tm_t tminit()        { tm_t t0=tmtime(),ts; while((ts = tmtime())==t0); return ts; }


### PR DESCRIPTION
When I built the project the error occurred as follow:

> cc -O3 -march=native -minline-all-stringops trlec.c -c -o trlec.o
cc -O3 -march=native -minline-all-stringops trled.c -c -o trled.o
cc -O2 -march=native -minline-all-stringops -c trle.c -o trle.o
In file included from trle.c:39:
./time_.h:78:9: warning: 'CLOCK_REALTIME' macro redefined [-Wmacro-redefined]
#define CLOCK_REALTIME 0
        ^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.12.sdk/usr/include/time.h:154:9: note:
      previous definition is here
#define CLOCK_REALTIME _CLOCK_REALTIME
        ^
In file included from trle.c:39:
./time_.h:79:9: warning: 'CLOCK_MONOTONIC' macro redefined [-Wmacro-redefined]
#define CLOCK_MONOTONIC 0
        ^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.12.sdk/usr/include/time.h:156:9: note:
      previous definition is here
#define CLOCK_MONOTONIC _CLOCK_MONOTONIC
        ^
In file included from trle.c:39:
./time_.h:80:5: error: conflicting types for 'clock_gettime'
int clock_gettime(int /*clk_id*/, struct timespec* t) {
    ^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.12.sdk/usr/include/time.h:177:5: note:
      previous declaration is here
int clock_gettime(clockid_t __clock_id, struct timespec *__tp);
    ^
In file included from trle.c:39:
./time_.h:80:33: error: parameter name omitted
int clock_gettime(int /*clk_id*/, struct timespec* t) {
                                ^
./time_.h:90:80: warning: while loop has empty body [-Wempty-body]
  ...tm_t tminit()        { tm_t t0=tmtime(),ts; while((ts = tmtime())==t0); return ts; }
                                                                           ^
./time_.h:90:80: note: put the semicolon on a separate line to silence this warning
3 warnings and 2 errors generated.
make: *** [trle.o] Error 1

Apple has implemented **clock_gettime** since 10.12 so there is no need to define it .

And maybe the library **lrt** is not available on MacOS (It works without -lrt). 