### PR TITLE
Add explicit RISC-V scalar fallback support

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 
 ##### Efficient and fastest **Run Length Encoding** library
   - ARM NEON support
+  - RISC-V scalar fallback support
   - 100% C (C++ compatible headers), without inline assembly
   - Most efficient compression 
   - No other RLE compress or decompress faster with better compression
@@ -150,6 +151,7 @@ for more info, see also: [Entropy Coding Benchmark](https://sites.google.com/sit
 - Linux amd64: Clang (>=3.2) 
 - Linux arm64: 64 bits aarch64 ARMv8:  gcc (>=6.3)
 - Linux arm64: 64 bits aarch64 ARMv8:  clang
+- Linux riscv64: scalar fallback path with a C99 compiler
 - MaxOS: XCode (>=9)
 - PowerPC ppc64le (incl. SIMD): gcc (>=8.0)
 

--- a/include_/conf.h
+++ b/include_/conf.h
@@ -181,6 +181,24 @@ static ALWAYS_INLINE void               stof64(      void *cp, double           
 static ALWAYS_INLINE void               ltou32(unsigned           *x, const void *cp) { memcpy(x, cp, sizeof(*x)); } // ua read into ptr 
 static ALWAYS_INLINE void               ltou64(unsigned long long *x, const void *cp) { memcpy(x, cp, sizeof(*x)); }
 
+  #elif defined(__riscv)
+#include <string.h>
+#define ctou16(_cp_) ({ unsigned short _x; memcpy(&_x, (_cp_), sizeof(_x)); _x; })
+#define ctou32(_cp_) ({ unsigned       _x; memcpy(&_x, (_cp_), sizeof(_x)); _x; })
+#define ctou64(_cp_) ({ uint64_t       _x; memcpy(&_x, (_cp_), sizeof(_x)); _x; })
+#define ctof32(_cp_) ({ float          _x; memcpy(&_x, (_cp_), sizeof(_x)); _x; })
+#define ctof64(_cp_) ({ double         _x; memcpy(&_x, (_cp_), sizeof(_x)); _x; })
+
+#define stou8(_cp_, _x_)  (*((uint8_t *)(_cp_)) = (_x_))
+#define stou16(_cp_, _x_) do { unsigned short _v = (_x_); memcpy((_cp_), &_v, sizeof(_v)); } while(0)
+#define stou32(_cp_, _x_) do { unsigned       _v = (_x_); memcpy((_cp_), &_v, sizeof(_v)); } while(0)
+#define stou64(_cp_, _x_) do { uint64_t       _v = (_x_); memcpy((_cp_), &_v, sizeof(_v)); } while(0)
+#define stof32(_cp_, _x_) do { float          _v = (_x_); memcpy((_cp_), &_v, sizeof(_v)); } while(0)
+#define stof64(_cp_, _x_) do { double         _v = (_x_); memcpy((_cp_), &_v, sizeof(_v)); } while(0)
+
+#define ltou32(_px_, _cp_) do { memcpy((_px_), (_cp_), sizeof(*(_px_))); } while(0)
+#define ltou64(_px_, _cp_) do { memcpy((_px_), (_cp_), sizeof(*(_px_))); } while(0)
+
   #elif defined(__i386__) || defined(__x86_64__) || \
     defined(_M_IX86) || defined(_M_AMD64) || _MSC_VER ||\
     defined(__powerpc__) || defined(__s390__) ||\
@@ -251,6 +269,7 @@ struct _PACKED doubleu   { double             d; };
     defined(__x86_64__) || defined(_M_X64) ||\
     defined(__ia64) || defined(_M_IA64) ||\
     defined(__aarch64__) ||\
+    (defined(__riscv) && (__riscv_xlen == 64)) ||\
     defined(__mips64) ||\
     defined(__powerpc64__) || defined(__ppc64__) || defined(__PPC64__) ||\
     defined(__s390x__)

--- a/include_/time_.h
+++ b/include_/time_.h
@@ -24,7 +24,7 @@
 //      time_.h : parameter free high precision time/benchmark functions
 #include <time.h>
 #include <float.h>
-  #ifdef _WIN32
+  #if defined(_WIN32) && !defined(__riscv)
 #include <windows.h>
     #ifndef sleep
 #define sleep(n) Sleep((n) * 1000)
@@ -104,13 +104,19 @@ static int    tmiszero(tm_t t)              { return !t; }
 #define TM_MBS "MB/s"
 static double TMBS(unsigned l, double t) { return (l/t)/1000000.0; }
 
-  #ifdef _WIN32 //-------- windows 
+  #if defined(_WIN32) && !defined(__riscv) //-------- windows 
 static LARGE_INTEGER tps;
 
 typedef unsigned __int64 tm_t;
 static tm_t   tmtime()                      { LARGE_INTEGER tm; tm_t t; QueryPerformanceCounter(&tm); return tm.QuadPart; }
 static tm_t   tminit()                      { tm_t t0,ts; QueryPerformanceFrequency(&tps); t0 = tmtime(); while((ts = tmtime())==t0) {}; return ts; }
 static double tmdiff(tm_t start, tm_t stop) { return (double)(stop - start)/tps.QuadPart; }
+static int    tmiszero(tm_t t)              { return !t; }
+  #elif defined(__riscv)
+typedef clock_t tm_t;
+static tm_t   tmtime()                      { return clock(); }
+static tm_t   tminit()                      { tm_t t0 = tmtime(), t; while((t = tmtime()) == t0) {}; return t; }
+static double tmdiff(tm_t start, tm_t stop) { return (double)(stop - start) / CLOCKS_PER_SEC; }
 static int    tmiszero(tm_t t)              { return !t; }
   #else        // Linux & compatible / MacOS
     #ifdef __APPLE__

--- a/makefile
+++ b/makefile
@@ -27,6 +27,10 @@ else
 
 ifneq (,$(findstring aarch64,$(CC)))
   ARCH = aarch64
+else ifneq (,$(findstring riscv64,$(CC)))
+  ARCH = riscv64
+else ifneq (,$(findstring riscv32,$(CC)))
+  ARCH = riscv32
 else ifneq (,$(findstring powerpc64le,$(CC)))
   ARCH = ppc64le
 endif
@@ -43,6 +47,9 @@ else
   CFLAGS+=-march=armv8-a 
 endif
   MSSE=-march=armv8-a
+else ifneq ($(filter riscv%,$(ARCH)),)
+  MARCH=
+  MSSE=
 else ifeq ($(ARCH),$(filter $(ARCH),x86_64 ppc64le))
   CFLAGS=-march=native
   MSSE=-mssse3

--- a/trle_.h
+++ b/trle_.h
@@ -40,9 +40,9 @@
 
 #define _vlput32(_op_, _x_, _act_) {\
   if(likely((_x_) < VL_OFS1)){ *_op_++ = (_x_);                                                                  _act_;}\
-  else if  ((_x_) < VL_OFS2) { ctou16(_op_) = bswap16((VL_OFS1<<8)+((_x_)-VL_OFS1));             _op_  += 2;     _act_;}\
-  else if  ((_x_) < VL_OFS3) { *_op_++ = VL_BA2 + (((_x_) -= VL_OFS2) >> 16); ctou16(_op_) = (_x_); _op_  += 2;  _act_;}\
-  else { unsigned _b = (bsr32((_x_))+7)/8; *_op_++ = VL_BA3 + (_b - 3); ctou32(_op_) = (_x_); _op_  += _b; _act_;}\
+  else if  ((_x_) < VL_OFS2) { stou16(_op_, bswap16((VL_OFS1<<8)+((_x_)-VL_OFS1)));             _op_  += 2;     _act_;}\
+  else if  ((_x_) < VL_OFS3) { *_op_++ = VL_BA2 + (((_x_) -= VL_OFS2) >> 16); stou16(_op_, (_x_)); _op_  += 2;  _act_;}\
+  else { unsigned _b = (bsr32((_x_))+7)/8; *_op_++ = VL_BA3 + (_b - 3); stou32(_op_, (_x_)); _op_  += _b; _act_;}\
 }
 
 #define _vlget32(_ip_, _x_, _act_) do { _x_ = *_ip_++;\

--- a/trled.c
+++ b/trled.c
@@ -225,12 +225,12 @@ unsigned _trled(const unsigned char *__restrict in, unsigned char *__restrict ou
     while(op < out+(outlen-32)) {
         #if __WORDSIZE == 64
       uint64_t z = (uint64_t)rmap[ip[7]]<<56 | (uint64_t)rmap[ip[6]] << 48 | (uint64_t)rmap[ip[5]] << 40 | (uint64_t)rmap[ip[4]] << 32 | (uint32_t)rmap[ip[3]] << 24 | (uint32_t)rmap[ip[2]] << 16| (uint32_t)rmap[ip[1]] << 8| rmap[ip[0]];
-      ctou64(op) = ctou64(ip); if(z) goto a; ip += 8; op += 8;
+      stou64(op, ctou64(ip)); if(z) goto a; ip += 8; op += 8;
       continue;
       a: z = ctz64(z)>>3;
         #else
       uint32_t z = (uint32_t)rmap[ip[3]] << 24 | (uint32_t)rmap[ip[2]] << 16| (uint32_t)rmap[ip[1]] << 8| rmap[ip[0]];
-      ctou32(op) = ctou32(ip); if(z) goto a; ip += 4; op += 4;
+      stou32(op, ctou32(ip)); if(z) goto a; ip += 4; op += 4;
       continue;
       a: z = ctz32(z)>>3;
         #endif
@@ -310,8 +310,8 @@ unsigned trled(const unsigned char *__restrict in, unsigned inlen, unsigned char
 #define rmemset(_op_, _c_, _i_) do {  uint64_t _cc; uint8_t *_up = (uint8_t *)_op_; _op_ +=_i_;\
  T2(_cset, USIZE)(_cc,_c_);\
   do {\
-    T2(ctou, USIZE)(_up) = _c_; _up += USIZE/8;\
-    T2(ctou, USIZE)(_up) = _c_; _up += USIZE/8;\
+    T2(stou, USIZE)(_up, _c_); _up += USIZE/8;\
+    T2(stou, USIZE)(_up, _c_); _up += USIZE/8;\
   } while(_up < (uint8_t *)_op_);\
 } while(0)
   #endif


### PR DESCRIPTION
## Why

`Turbo-Run-Length-Encoding` already has a generic scalar implementation, but `riscv64` was still only covered implicitly and could fall back to host-oriented assumptions in two places:

- the `makefile` did not recognize `riscv64` / `riscv32`, so cross builds could still inherit x86-oriented defaults such as `-march=native` and `-mssse3`;
- `include_/conf.h` relied on architecture checks that, under a forced-RISC-V validation build on MinGW, could still be short-circuited by host macros before reaching a RISC-V-safe unaligned-access path.

In addition, a few write sites assumed helpers like `ctou16` / `ctou32` were lvalues, which does not hold once the RISC-V path uses memcpy-style accessors.

This patch makes the existing scalar path explicit and verifiable for RISC-V without adding RVV intrinsics or changing the current x86 / ARM optimized paths.

## What changed

- Updated `makefile`:
  - detect `riscv64` / `riscv32` from the compiler name;
  - avoid injecting x86-specific defaults such as `-march=native` and `-mssse3` for RISC-V targets.
- Updated `include_/conf.h`:
  - add an explicit RISC-V unaligned-access branch ahead of host-x86 fallback checks;
  - provide memcpy-based `ctou16/32/64`, `ctof32/64`, `stou8/16/32/64`, `stof32/64`, and `ltou32/64`;
  - mark `__riscv_xlen == 64` as a 64-bit target for `__WORDSIZE`.
- Updated `include_/time_.h`:
  - keep forced-RISC-V smoke builds on a conservative timer path instead of inheriting `_WIN32`-specific assumptions.
- Updated `trle_.h`:
  - replace variable-length encoding write sites that used `ctou16` / `ctou32` as lvalues with `stou16` / `stou32`.
- Updated `trled.c`:
  - replace generic write sites with `stou32` / `stou64` / `T2(stou, USIZE)` so the scalar RISC-V path remains valid.
- Updated `README.md`:
  - document that Linux `riscv64` currently uses the scalar fallback path.

## Verification

- Ran native build successfully:
  - `gmake`
- Ran simulated `riscv64` dry-run successfully:
  - `gmake -n ARCH=riscv64 CC=riscv64-linux-gnu-gcc`
- Confirmed the simulated `riscv64` dry-run:
  - does not inject `-march=native`;
  - does not inject `-mssse3`.
- Confirmed forced-RISC-V macros in `conf.h`:
  - `gcc -E -dM -D__riscv=1 -D__riscv_xlen=64 -U__x86_64__ -U__amd64__ -U__aarch64__ -U__ARM_NEON -U__AVX2__ -U__AVX__ -U__SSE4_1__ -U__SSSE3__ -U__SSE3__ -U__SSE2__ -U__SSE__ -U__LP64__ -U_LP64 -U_WIN64 -U_M_X64 macro_probe.c`
  - verified `ctou16/32/64`, `stou8/16/32/64`, and `__WORDSIZE 64` are defined under forced `__riscv`.
- Ran forced-RISC-V source compiles successfully:
  - `gcc -c -D__riscv=1 -D__riscv_xlen=64 -U__x86_64__ -U__amd64__ -U__aarch64__ -U__ARM_NEON -U__AVX2__ -U__AVX__ -U__SSE4_1__ -U__SSSE3__ -U__SSE3__ -U__SSE2__ -U__SSE__ -U__LP64__ -U_LP64 -U_WIN64 -U_M_X64 trlec.c -o NUL`
  - `gcc -c -D__riscv=1 -D__riscv_xlen=64 -U__x86_64__ -U__amd64__ -U__aarch64__ -U__ARM_NEON -U__AVX2__ -U__AVX__ -U__SSE4_1__ -U__SSSE3__ -U__SSE3__ -U__SSE2__ -U__SSE__ -U__LP64__ -U_LP64 -U_WIN64 -U_M_X64 trled.c -o NUL`
  - `gcc -c -D__riscv=1 -D__riscv_xlen=64 -U__x86_64__ -U__amd64__ -U__aarch64__ -U__ARM_NEON -U__AVX2__ -U__AVX__ -U__SSE4_1__ -U__SSSE3__ -U__SSE3__ -U__SSE2__ -U__SSE__ -U__LP64__ -U_LP64 -U_WIN64 -U_M_X64 trle.c -o NUL`
- Ran a full forced-RISC-V make successfully:
  - `gmake ARCH=riscv64 "CC=gcc -D__riscv=1 -D__riscv_xlen=64 -U__x86_64__ -U__amd64__ -U__aarch64__ -U__ARM_NEON -U__AVX2__ -U__AVX__ -U__SSE4_1__ -U__SSSE3__ -U__SSE3__ -U__SSE2__ -U__SSE__ -U__LP64__ -U_LP64 -U_WIN64 -U_M_X64"`
- Verified a real `riscv64` executable in `dockcross/linux-riscv64:20260515-5fd14ac`:
  - built `trle` with `make ARCH=riscv64 CC=/usr/xcc/riscv64-unknown-linux-gnu/bin/riscv64-unknown-linux-gnu-gcc`;
  - confirmed `trle` with `file` and `readelf -h`, which reported a real `RISC-V` ELF (`Machine: RISC-V`);
  - confirmed the real build log contains no `-march=native` or `-mssse3`;
  - ran `trle -e 1 sample.bin` under `qemu-riscv64` and got a successful encode/decode round-trip with no `ERROR` output;
  - ran the default all-algorithm mode under `qemu-riscv64` on the same sample file and again saw no `ERROR`, covering `trle`, `srle`, `mrle`, and the memcpy baseline path.

## Notes

- This is a conservative portability patch. It does not add RVV kernels or RISC-V-specific performance tuning.
- The goal is to make the existing scalar implementation explicit, buildable, and verifiable for `riscv64`.